### PR TITLE
Change `clean` to a double-colon rule

### DIFF
--- a/src/incatools/odk/templates/_dynamic_files.jinja2
+++ b/src/incatools/odk/templates/_dynamic_files.jinja2
@@ -191,6 +191,10 @@ Datatype: rdf:PlainLiteral
 imports/%_import.owl: mirror/%.owl
 	echo "ERROR: You have configured your default module type to be custom; this behavior needs to be overwritten in {{ project.id }}.Makefile!" && touch $@
 {%   endif -%}
+
+.PHONY: clean
+clean::
+	# Add any custom cleaning logic here.
 {%   if project.import_group.use_base_merging -%}
 {#
 

--- a/src/incatools/odk/templates/src/ontology/Makefile.jinja2
+++ b/src/incatools/odk/templates/src/ontology/Makefile.jinja2
@@ -1585,8 +1585,11 @@ update_docs:
 # current directory is a way to ensure we only clean up directories that
 # are located below the current directory, regardless of the contents of
 # the *DIR variables.
+#
+# This is a double-colon rule to allow another clean target to be defined
+# in {{ project.id }}.Makefile without overriding this one.
 .PHONY: clean
-clean:{% if project.use_dosdps %}
+clean::{% if project.use_dosdps %}
 	$(MAKE) pattern_clean{%- endif %}
 	for dir in $(MIRRORDIR) $(TMPDIR) $(UPDATEREPODIR) ; do      \
 		reldir=$$(realpath --relative-to=$$(pwd) $$dir) ;    \


### PR DESCRIPTION
This commit changes `clean` to a double-colon to allow local project Makefiles to also define a `clean` rule without overriding the top-level one. A stub for a double-colon `clean` rule is placed into the project Makefile as well.

See <https://www.gnu.org/software/make/manual/html_node/Double_002dColon.html>

Addresses <https://github.com/INCATools/ontology-development-kit/issues/1284>