### PR TITLE
Report the "base roots" when checking alignment.

### DIFF
--- a/src/incatools/odk/setup.py
+++ b/src/incatools/odk/setup.py
@@ -24,7 +24,7 @@ DICER_SOURCE = "https://github.com/gouttegd/dicer/releases/download/dicer-0.2.1/
 SSSOM_SOURCE = "https://github.com/gouttegd/sssom-java/releases/download/sssom-java-1.10.0/sssom-cli-1.10.0.jar"
 DOSDP_SOURCE = "https://github.com/INCATools/dosdp-tools/releases/download/v0.19.3/dosdp-tools-0.19.3.tgz"
 RELGR_SOURCE = "https://github.com/INCATools/relation-graph/releases/download/v2.3.3/relation-graph-cli-2.3.3.tgz"
-ODK_PLUGIN_SOURCE = "https://github.com/INCATools/odk-robot-plugin/releases/download/odk-robot-plugin-0.3.0/odk.jar"
+ODK_PLUGIN_SOURCE = "https://github.com/INCATools/odk-robot-plugin/releases/download/odk-robot-plugin-0.3.1/odk.jar"
 SSSOM_PLUGIN_SOURCE = "https://github.com/gouttegd/sssom-java/releases/download/sssom-java-1.10.0/sssom-robot-plugin-1.10.0.jar"
 OBO_EPM_SOURCE = "https://raw.githubusercontent.com/biopragmatics/bioregistry/main/exports/contexts/obo.epm.json"
 

--- a/src/incatools/odk/templates/src/ontology/Makefile.jinja2
+++ b/src/incatools/odk/templates/src/ontology/Makefile.jinja2
@@ -373,6 +373,7 @@ $(REPORTDIR)/$(SRC)-align-report.tsv: $(SRCMERGED) | $(REPORTDIR) all_robot_plug
 	$(ROBOT) odk:check-align -i $< --reasoner $(REASONER) \
 		 --upper-ontology-iri {{ project.robot.report.upper_ontology }}
 		 {%- if project.robot.report.use_base_iris %} \
+		 --detail BASE-ROOT \
 		 {% if project.namespaces is not none %}{% for iri in project.namespaces %}--base-iri {{ iri }} \
 		 {% endfor %}{% else %}--base-iri $(URIBASE)/{{ project.id.upper() }}_ --base-iri $(URIBASE)/{{ project.id }} \
 		 {% endif %}{% else %} \
@@ -382,6 +383,7 @@ $(REPORTDIR)/%-align-report.tsv: % | $(REPORTDIR) all_robot_plugins
 	$(ROBOT) odk:check-align -i $< --reasoner $(REASONER) \
 		 --upper-ontology-iri {{ project.robot.report.upper_ontology }}
 		 {%- if project.robot.report.use_base_iris %} \
+		 --detail BASE-ROOT \
 		 {% if project.namespaces is not none %}{% for iri in project.namespaces %}--base-iri {{ iri }} \
 		 {% endfor %}{% else %}--base-iri $(URIBASE)/{{ project.id.upper() }}_ --base-iri $(URIBASE)/{{ project.id }} \
 		 {% endif %}{% else %} \


### PR DESCRIPTION
If the alignment check is restricted to base entities only (option `robot.report.use_base_iris` set to True), then we ask the `odk:check-align` command to report, not only the top-level unaligned classes, but the all unaligned classes down to the highest "in-base" ancestors.

Presumably if the ontology owner is only interested in the alignment of their own classes, they'd want to know what are highest unaligned classes **in their ontology's namespace(s)**.