### PR TITLE
Replace `use_base` option by a generic `use_variant` option.

### DIFF
--- a/src/incatools/odk/config.py
+++ b/src/incatools/odk/config.py
@@ -193,7 +193,7 @@ def update_config_dict(obj: Dict[str, Any]) -> None:
     # First take care of stubs, if needed
     update_stubs(obj)
 
-    # Then all the other changes
+    # Then all the other simple changes
     changes = [
         # old key path               new key path
         ("reasoner", "robot.reasoner"),
@@ -212,6 +212,16 @@ def update_config_dict(obj: Dict[str, Any]) -> None:
                 put_key(obj, new, v)
             else:
                 logging.warning(f"Option {old} is deprecated")
+
+    # Then the more complex changes, that cannot be handled simply by
+    # renaming or moving keys around.
+
+    # `use_base: True` ==> `use_variant: base`
+    if "import_group" in obj:
+        for imp in obj["import_group"]["products"]:
+            use_base = imp.pop("use_base", False)
+            if use_base:
+                imp["use_variant"] = "base"
 
 
 def pop_key(obj: Dict[str, Any], path: str) -> Optional[str]:

--- a/src/incatools/odk/model.py
+++ b/src/incatools/odk/model.py
@@ -205,8 +205,8 @@ class ImportProduct(Product):
     for the list of allowed values and their meaning.
     """
 
-    use_base: bool = False
-    """If true, download the -base version of the upstream source.
+    use_variant: Optional[str] = None
+    """If set, use the specified variant of the ontology.
 
     Only meaningful if ``mirror_from`` is not set, that is if the
     upstream source is downloaded from http://purl.obolibrary.org/obo/.

--- a/src/incatools/odk/templates/src/ontology/Makefile.jinja2
+++ b/src/incatools/odk/templates/src/ontology/Makefile.jinja2
@@ -887,7 +887,7 @@ download-mirror-{{ ont.id }}: | $(TMPDIR)
 	odk-helper download --output $(TMPDIR)/$@.owl \
 	                    --reference $(MIRRORDIR)/{{ ont.id }}.owl \
 	                    --max-retry {{ project.import_group.mirror_retry_download }} \
-	                    {% if ont.mirror_from %}{{ ont.mirror_from }}{% elif ont.use_base %}$(OBOBASE)/{{ ont.id }}/{{ ont.id }}-base.owl{% if ont.use_gzipped %}.gz{% endif %}{% else %}$(OBOBASE)/{{ ont.id }}.owl{% if ont.use_gzipped %}.gz{% endif %}{% endif %}
+	                    {% if ont.mirror_from %}{{ ont.mirror_from }}{% elif ont.use_variant is not none %}$(OBOBASE)/{{ ont.id }}/{{ ont.id }}-{{ ont.use_variant }}.owl{% if ont.use_gzipped %}.gz{% endif %}{% else %}$(OBOBASE)/{{ ont.id }}.owl{% if ont.use_gzipped %}.gz{% endif %}{% endif %}
 
 {%       if ont.mirror_type == 'custom' -%}
 $(MIRRORDIR)/{{ ont.id }}.owl:

--- a/tests/configs/test-use-variant.yaml
+++ b/tests/configs/test-use-variant.yaml
@@ -1,0 +1,20 @@
+id: tvariant
+title: "Test Variant"
+github_org: INCATools
+repo: ontology-development-kit
+import_group:
+  use_base_merging: true
+  exclude_iri_patterns:
+    - <http://purl.obolibrary.org/obo/GOCHE_*>
+    - <http://purl.obolibrary.org/obo/OBA_*>
+  slme_individuals: exclude
+  mirror_max_time_download: 400
+  products:
+    - id: ro
+      mirror_from: https://raw.githubusercontent.com/INCATools/ontology-development-kit/master/tests/ontologies/ro.owl
+    - id: pato
+      use_variant: base
+      # This test cannot be easily replaced, because use_variant and custom URL dont mix
+    - id: pr
+      make_base: true
+      mirror_from: https://raw.githubusercontent.com/INCATools/ontology-development-kit/master/tests/ontologies/pr_slim.owl


### PR DESCRIPTION
This PR generalizes the `use_base: True` option by replacing it by a new `use_variant` option, which takes the name of the ontology variant to use as an argument.

For any given import IMP, setting `use_variant` to `FOO` instructs the ODK to download the IMP ontology from `http://purl.obolibrary.org/obo/IMP/IMP-FOO.owl`.

This option is intended to make it easier to import arbitrary ontology variants without having to always specify their full URL using `mirror_from`.

The old `use_base: True` option is exactly equivalent to `use_variant: base`, and whenever the old option is encountered in a configuration file, it is automatically interpreted as such.

closes INCATools/ontology-development-kit#1321