### PR TITLE
Make sure we are using synchronized versions of LinkML packages.

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -14,7 +14,7 @@ classifiers = [
     "Intended Audience :: Science/Research",
     "Topic :: Scientific/Engineering",
 ]
-requires-python = ">=3.9"
+requires-python = ">=3.10"
 dependencies = [
     "click",
     "dacite",
@@ -68,6 +68,14 @@ workflows = [
     "babelon",
     "dosdp",
     "lightrdf",
+    # We do not actually need LinkML directly, but we need to make sure
+    # our dependencies use version 1.10.0 for BOTH `linkml` and
+    # `linkml-runtime`; otherwise we could end up with linkml <= 1.9.6
+    # coupled with linkml-runtime >= 1.10.0, and that combination is
+    # broken because linkml-runtime introduced a breaking change
+    # ("semantic versioning? what is that?").
+    "linkml>=1.10.0",
+    "linkml-runtime>=1.10.0",
     "mkdocs",
     "mkdocs-material",
     "mkdocs-mermaid2-plugin",


### PR DESCRIPTION
Some of the Python dependencies we need to run workflows are themselves dependent on LinkML, which means they cause the installation of both `linkml` and its dependency `linkml-runtime`.

It seems that these two packages must always be kept "in sync", but there are no explicit constraints in either of them to enforce that.

So, we can end up `linkml` version 1.9.5 coupled with `linkml-runtime` version 1.10.0. That combination is perfectly valid according to the various version constraints (there is _no_ formal constraint that `linkml` 1.9.5 must use `linkml-runtime` < 1.10.0 -- and unless I missed something there is also no warning in the documentation that users should take care of always using the same version of these two packages), but it is broken in practice, because of some breaking changes that happened in `linkml-runtime` 1.10.0 (removal of a `Format.JSON` enumeration value).

Sigh. Not only did the LinkML developers remove a public symbol in a minor release, they did so without so much as a warning in the release notes. LinkML, I obscenity in the milk of thy callous disregard for semantic versioning.

So in this commit, we explicitly declare that we require version 1.10.0 at least of _both_ `linkml` and `linkml-runtime`.