### PR TITLE
Import components when seeding the `-edit` file.

### DIFF
--- a/src/incatools/odk/templates/_dynamic_files.jinja2
+++ b/src/incatools/odk/templates/_dynamic_files.jinja2
@@ -32,6 +32,11 @@ import: {{ project.uribase }}/{% if project.uribase_suffix is not none %}{{ proj
 {%         endfor -%}
 {%       endif -%}
 {%     endif -%}
+{%     if project.components is defined -%}
+{%       for component in project.components.products -%}
+import: {{ project.uribase }}/{% if project.uribase_suffix is not none %}{{ project.uribase_suffix }}{% else %}{{ project.id }}{% endif %}/components/{{ component.filename }}
+{%       endfor -%}
+{%     endif -%}
 {%     if project.use_dosdps -%}
 import: {{ project.uribase }}/{% if project.uribase_suffix is not none %}{{ project.uribase_suffix }}{% else %}{{ project.id }}{% endif %}/patterns/definitions.owl
 {%       if project.import_pattern_ontology -%}
@@ -85,7 +90,11 @@ Import(<{{ project.uribase }}/{% if project.uribase_suffix is not none %}{{ proj
 {%         endfor -%}
 {%       endif -%}
 {%     endif %}
-
+{%     if project.components is defined -%}
+{%       for component in project.components.products -%}
+Import(<{{ project.uribase }}/{% if project.uribase_suffix is not none %}{{ project.uribase_suffix }}{% else %}{{ project.id }}{% endif %}/components/{{ component.filename }}>)
+{%       endfor -%}
+{%     endif -%}
 {%     if project.use_dosdps -%}
 Import(<{{ project.uribase }}/{% if project.uribase_suffix is not none %}{{ project.uribase_suffix }}{% else %}{{ project.id }}{% endif %}/patterns/definitions.owl>)
 {%       if project.import_pattern_ontology -%}


### PR DESCRIPTION
When seeding a new repository, if the ODK is configured to manage import declarations, then we should generate import declarations not only for the import modules and the patterns-derived definitions, but also for the components. This is what this PR does.

Without that, the ODK behaves inconsistently in that it will properly inject all the import declarations (for import modules, components, and patterns-derived definitions) when a repository is _updated_, but will not inject the import declarations for components when the repository is _seeded_ for the first time.

Addresses https://github.com/INCATools/ontology-development-kit/issues/1331 ([this comment](https://github.com/INCATools/ontology-development-kit/issues/1331#issuecomment-4271033192)).