### PR TITLE
Exclude x86_64 macOS from the seeding tests.

### DIFF
--- a/.github/workflows/seed-tests.yml
+++ b/.github/workflows/seed-tests.yml
@@ -23,9 +23,12 @@ jobs:
     strategy:
       matrix:
         # We run the seeding tests using a "native" ODK environments;
-        # those will never be supported on Windows, but they SHOULD
-        # work on x86 GNU/Linux and both x86 and arm64 macOS.
-        os: [ ubuntu-latest, macos-15, macos-15-intel ]
+        # those will never be supported on Windows, but they SHOULD work
+        # on x86 GNU/Linux and both x86 and arm64 macOS.
+        # However we do NOT routinely test on x64 macOS because GitHub
+        # Actions runners for that platform are twice slower than the
+        # the runners for arm64 macOS, and it is just not worth it.
+        os: [ ubuntu-latest, macos-15 ]
     steps:
       - name: Check out the repository
         uses: actions/checkout@v4


### PR DESCRIPTION
Running the seeding tests using the "native" ODK setup takes about:

* 18 to 22 minutes on the x86_64 GNU/Linux (Ubuntu) runners;
* 15 to 18 minutes on the arm64 macOS runners;
* 35 to 40 minutes on the x86_64 macOS runners.

So for some reason, it takes twice as much time to run the seeding tests on x86_64 macOS than on arm64 macOS.

Given how few people seem to use the ODK on x86_64 macOS machines, systematically testing the native ODK setup for this platform does not seem worth it -- it is expected that very few ODK users will ever use the native setup anyway (Docker remains the primary way of using the ODK, at least for now), so the intersection of "ODK users on x86_64 macOS" and "ODK users willing to use the native setup" might very well be the empty set.

The native setup will still be _supported_ (for now?) on x86_64 macOS -- it will just not be _tested_ as much as for the x86_64 GNU/Linux and arm64 macOS platforms.