### PR TITLE
Update all GitHub Actions.

### DIFF
--- a/src/incatools/odk/templates/_dynamic_workflows.jinja2
+++ b/src/incatools/odk/templates/_dynamic_workflows.jinja2
@@ -80,7 +80,7 @@ jobs:
     # Steps represent a sequence of tasks that will be executed as part of the job
     steps:
       # Checks-out your repository under $GITHUB_WORKSPACE, so your job can access it
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@v6
 
       - name: Run ontology QC checks
         env:
@@ -106,16 +106,16 @@ jobs:
     runs-on: ubuntu-latest
     container: obolibrary/odklite:{% if env is defined -%}{{env['ODK_VERSION'] or "latest" }}{%- else %}latest{% endif %}
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@v6
       # Checks-out main branch under "main" directory
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@v6
         with:
           ref: master
           path: master
       - name: Diff classification
         run: export ROBOT_JAVA_ARGS=-Xmx6G; robot diff --labels True --left master/src/ontology/{{ project.id }}-edit.{{ project.edit_format }} --left-catalog master/src/ontology/catalog-v001.xml --right src/ontology/{{ project.id }}-edit.{{ project.edit_format }} --right-catalog src/ontology/catalog-v001.xml -f markdown -o edit-diff.md
       - name: Upload diff
-        uses: actions/upload-artifact@v4
+        uses: actions/upload-artifact@v7
         with:
           name: edit-diff.md
           path: edit-diff.md
@@ -123,11 +123,11 @@ jobs:
     runs-on: ubuntu-latest
     container: obolibrary/odklite:{% if env is defined -%}{{env['ODK_VERSION'] or "latest" }}{%- else %}latest{% endif %}
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@v6
       - name: Classify ontology
         run: cd src/ontology; make IMP=FALSE PAT=FALSE MIR=FALSE {{ project.id }}.owl
       - name: Upload PR {{ project.id }}.owl
-        uses: actions/upload-artifact@v4
+        uses: actions/upload-artifact@v7
         with:
           name: {{ project.id }}-pr.owl
           path: src/ontology/{{ project.id }}.owl
@@ -136,13 +136,13 @@ jobs:
     runs-on: ubuntu-latest
     container: obolibrary/odklite:{% if env is defined -%}{{env['ODK_VERSION'] or "latest" }}{%- else %}latest{% endif %}
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@v6
         with:
           ref: master
       - name: Classify ontology
         run: cd src/ontology; make IMP=FALSE PAT=FALSE MIR=FALSE {{ project.id }}.owl
       - name: Upload master {{ project.id }}.owl
-        uses: actions/upload-artifact@v4
+        uses: actions/upload-artifact@v7
         with:
           name: {{ project.id }}-master.owl
           path: src/ontology/{{ project.id }}.owl
@@ -154,21 +154,21 @@ jobs:
     runs-on: ubuntu-latest
     container: obolibrary/odklite:{% if env is defined -%}{{env['ODK_VERSION'] or "latest" }}{%- else %}latest{% endif %}
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@v6
       - name: Download master classification
-        uses: actions/download-artifact@v4
+        uses: actions/download-artifact@v8
         with:
           name: {{ project.id }}-master.owl
           path: src/ontology/{{ project.id }}-master.owl
       - name: Download PR classification
-        uses: actions/download-artifact@v4
+        uses: actions/download-artifact@v8
         with:
           name: {{ project.id }}-pr.owl
           path: src/ontology/{{ project.id }}-pr.owl
       - name: Diff classification
         run: export ROBOT_JAVA_ARGS=-Xmx6G; cd src/ontology; robot diff --labels True --left {{ project.id }}-master.owl/{{ project.id }}.owl --left-catalog catalog-v001.xml --right {{ project.id }}-pr.owl/{{ project.id }}.owl --right-catalog catalog-v001.xml -f markdown -o classification-diff.md
       - name: Upload diff
-        uses: actions/upload-artifact@v4
+        uses: actions/upload-artifact@v7
         with:
           name: classification-diff.md
           path: src/ontology/classification-diff.md
@@ -176,9 +176,9 @@ jobs:
     needs: [diff_classification, edit_file]
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@v6
       - name: Download reasoned diff
-        uses: actions/download-artifact@v4
+        uses: actions/download-artifact@v8
         with:
           name: classification-diff.md
           path: classification-diff.md
@@ -187,13 +187,13 @@ jobs:
       - name: Post reasoned comment
         env:
           GITHUB_TOKEN: {% raw %}${{ secrets.GITHUB_TOKEN }}{% endraw %}
-        uses: NejcZdovc/comment-pr@v1.1.1
+        uses: NejcZdovc/comment-pr@v2
         with:
           file: "../../comment.md"
           identifier: "REASONED"
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@v6
       - name: Download edit diff
-        uses: actions/download-artifact@v4
+        uses: actions/download-artifact@v8
         with:
           name: edit-diff.md
           path: edit-diff.md
@@ -202,7 +202,7 @@ jobs:
       - name: Post comment
         env:
           GITHUB_TOKEN: {% raw %}${{ secrets.GITHUB_TOKEN }}{% endraw %}
-        uses: NejcZdovc/comment-pr@v1.1.1
+        uses: NejcZdovc/comment-pr@v2
         with:
           file: "../../edit-comment.md"
           identifier: "UNREASONED"
@@ -226,7 +226,7 @@ jobs:
   post_diff:
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@v6
       - name: Prepare release comment
         env:
             GITHUB_SHA: {% raw %}${{ github.sha }}{% endraw %}
@@ -234,7 +234,7 @@ jobs:
       - name: Post reasoned comment
         env:
           GITHUB_TOKEN: {% raw %}${{ secrets.GITHUB_TOKEN }}{% endraw %}
-        uses: NejcZdovc/comment-pr@v2.0.0
+        uses: NejcZdovc/comment-pr@v2
         with:
           github_token: {% raw %}${{ env.GITHUB_TOKEN }}{% endraw %}
           file: "../../comment.md"
@@ -260,7 +260,7 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - name: Checkout main
-        uses: actions/checkout@v4
+        uses: actions/checkout@v6
 
       - name: Deploy docs
         uses: mhausenblas/mkdocs-deploy-gh-pages@master


### PR DESCRIPTION
Update all references to third-party GitHub Actions to use the current latest versions:

* actions/checkout: v4 -> v6
* actions/upload-artifact: v4 -> v7
* actions/download-artifact: v4 -> v8
* NejcZdovc/comment-pr: v1.1.1 -> v2

This is a temporary fix to https://github.com/INCATools/ontology-development-kit/issues/1346. A more permanent fix would be update the templating system so that it can automatically use the latest version of the aforementioned actions at the time the templates are instantiated.