### PR TITLE
Do not error out if the first download attempt fails for any reason.

### DIFF
--- a/src/incatools/odk/download.py
+++ b/src/incatools/odk/download.py
@@ -161,9 +161,6 @@ def download_file(
             elif response.status_code == 304:
                 logging.info(f"{output.name}: Not modified at {url}")
                 return 304
-            elif response.status_code == 404:
-                logging.warning(f"{output.name}: Not found at {url}")
-                return 404
             elif response.status_code in RETRIABLE_HTTP_ERRORS and n_try < max_retry:
                 n_try += 1
                 logging.warning(

--- a/src/incatools/odk/download.py
+++ b/src/incatools/odk/download.py
@@ -181,8 +181,10 @@ def download_file(
                 raise DownloadError(f"Timeout when connecting to {hostname}")
         except requests.exceptions.ConnectionError:
             raise DownloadError(f"Cannot connect to {hostname}")
-        except requests.exceptions.HTTPError:
-            raise DownloadError(f"HTTP error when downloading {url}")
+        except requests.exceptions.HTTPError as e:
+            raise DownloadError(
+                f"HTTP {e.response.status_code} error when downloading {url}"
+            )
         except requests.exceptions.ReadTimeout:
             raise DownloadError(f"Timeout when downloading {url}")
 

--- a/src/incatools/odk/helper.py
+++ b/src/incatools/odk/helper.py
@@ -204,15 +204,14 @@ def download(url, output, reference, cache_info, max_retry, try_gzip) -> None:
         if reference != output and output.exists():
             output.unlink()
 
-    try:
-        for u, c in attempts:
-            status = download_file(u, output, info, max_retry, c)
+    for i, attempt in enumerate(attempts):
+        try:
+            status = download_file(attempt[0], output, info, max_retry, attempt[1])
             if status == 200:
                 info.to_file(cache_info)
                 return
             elif status == 304:
                 return
-        if status == 404:  # Last attempt failed
-            raise click.ClickException(f"Cannot download {url}: 404 Not Found")
-    except DownloadError as e:
-        raise click.ClickException(f"Cannot download {url}: {e}")
+        except DownloadError as e:
+            if i == len(attempt) - 1:
+                raise click.ClickException(f"Cannot download {url}: {e}")

--- a/src/incatools/odk/helper.py
+++ b/src/incatools/odk/helper.py
@@ -206,6 +206,7 @@ def download(url, output, reference, cache_info, max_retry, try_gzip) -> None:
 
     for i, attempt in enumerate(attempts):
         try:
+            logging.info(f"{output.name}: Trying download from <{attempt[0]}>")
             status = download_file(attempt[0], output, info, max_retry, attempt[1])
             if status == 200:
                 info.to_file(cache_info)
@@ -215,3 +216,7 @@ def download(url, output, reference, cache_info, max_retry, try_gzip) -> None:
         except DownloadError as e:
             if i == len(attempts) - 1:
                 raise click.ClickException(f"Cannot download {url}: {e}")
+            else:
+                logging.warning(
+                    f"{output.name}: Download failed from <{attempt[0]}>: {e}"
+                )

--- a/src/incatools/odk/helper.py
+++ b/src/incatools/odk/helper.py
@@ -213,5 +213,5 @@ def download(url, output, reference, cache_info, max_retry, try_gzip) -> None:
             elif status == 304:
                 return
         except DownloadError as e:
-            if i == len(attempt) - 1:
+            if i == len(attempts) - 1:
                 raise click.ClickException(f"Cannot download {url}: {e}")


### PR DESCRIPTION
This commit reorders the exception handling logic within the `odk-helper download` command.

We catch download errors _inside_ the loop on download attempts, rather than _outside_, so that a failed download attempt (for any reason at all) does not automatically cause the command to error out without even trying the remaining attempts. Only when the _last_ attempt fails do we actually error out.

This fixes INCATools/ontology-development-kit#1349.