### PR TITLE
Add basic support for ORCIDIO.

### DIFF
--- a/src/incatools/odk/model.py
+++ b/src/incatools/odk/model.py
@@ -1143,6 +1143,9 @@ class OntologyProject(JsonSchemaMixin):
     release_diff: bool = False
     """Generates a diff with the previous release."""
 
+    orcidio_support: bool = False
+    """Extracts ORCIDIO individuals representing the contributors to the ontology."""
+
     robot: RobotOptionsGroup = field(default_factory=lambda: RobotOptionsGroup())
     """ROBOT-related options."""
 

--- a/src/incatools/odk/model.py
+++ b/src/incatools/odk/model.py
@@ -1144,7 +1144,14 @@ class OntologyProject(JsonSchemaMixin):
     """Generates a diff with the previous release."""
 
     orcidio_support: bool = False
-    """Extracts ORCIDIO individuals representing the contributors to the ontology."""
+    """Enables the automatic production of an ORCIDIO import module.
+
+    If enabled, this option will cause the build pipeline to (1) scan
+    the ontology for references to ORCID identifiers in all IRI-valued
+    annotations, and (2) create a orcidio_import.owl import module
+    containing all ORCIDIO individuals corresponding to the referenced
+    ORCID identifiers.
+    """
 
     robot: RobotOptionsGroup = field(default_factory=lambda: RobotOptionsGroup())
     """ROBOT-related options."""

--- a/src/incatools/odk/setup.py
+++ b/src/incatools/odk/setup.py
@@ -24,7 +24,7 @@ DICER_SOURCE = "https://github.com/gouttegd/dicer/releases/download/dicer-0.2.1/
 SSSOM_SOURCE = "https://github.com/gouttegd/sssom-java/releases/download/sssom-java-1.11.2/sssom-cli-1.11.2.jar"
 DOSDP_SOURCE = "https://github.com/INCATools/dosdp-tools/releases/download/v0.20.0/dosdp-tools-0.20.0.tgz"
 RELGR_SOURCE = "https://github.com/INCATools/relation-graph/releases/download/v2.3.4/relation-graph-cli-2.3.4.tgz"
-ODK_PLUGIN_SOURCE = "https://github.com/INCATools/odk-robot-plugin/releases/download/odk-robot-plugin-0.3.2/odk.jar"
+ODK_PLUGIN_SOURCE = "https://github.com/INCATools/odk-robot-plugin/releases/download/odk-robot-plugin-0.3.3/odk.jar"
 SSSOM_PLUGIN_SOURCE = "https://github.com/gouttegd/sssom-java/releases/download/sssom-java-1.11.2/sssom-robot-plugin-1.11.2.jar"
 OBO_EPM_SOURCE = "https://raw.githubusercontent.com/biopragmatics/bioregistry/main/exports/contexts/obo.epm.json"
 

--- a/src/incatools/odk/setup.py
+++ b/src/incatools/odk/setup.py
@@ -24,7 +24,7 @@ DICER_SOURCE = "https://github.com/gouttegd/dicer/releases/download/dicer-0.2.1/
 SSSOM_SOURCE = "https://github.com/gouttegd/sssom-java/releases/download/sssom-java-1.11.2/sssom-cli-1.11.2.jar"
 DOSDP_SOURCE = "https://github.com/INCATools/dosdp-tools/releases/download/v0.20.0/dosdp-tools-0.20.0.tgz"
 RELGR_SOURCE = "https://github.com/INCATools/relation-graph/releases/download/v2.3.4/relation-graph-cli-2.3.4.tgz"
-ODK_PLUGIN_SOURCE = "https://github.com/INCATools/odk-robot-plugin/releases/download/odk-robot-plugin-0.3.1/odk.jar"
+ODK_PLUGIN_SOURCE = "https://github.com/INCATools/odk-robot-plugin/releases/download/odk-robot-plugin-0.3.2/odk.jar"
 SSSOM_PLUGIN_SOURCE = "https://github.com/gouttegd/sssom-java/releases/download/sssom-java-1.11.2/sssom-robot-plugin-1.11.2.jar"
 OBO_EPM_SOURCE = "https://raw.githubusercontent.com/biopragmatics/bioregistry/main/exports/contexts/obo.epm.json"
 

--- a/src/incatools/odk/template.py
+++ b/src/incatools/odk/template.py
@@ -394,6 +394,8 @@ class Generator(object):
             cmd += f" --add {base}/patterns/definitions.owl"
             if self.project.import_pattern_ontology:
                 cmd += f" --add {base}/patterns/pattern.owl"
+        if self.project.orcidio_support:
+            cmd += f" --add {base}/imports/orcidio_import.owl"
 
         if self.project.edit_format == "owl":
             cmd += f" convert -f ofn -o {self.project.id}-edit.owl"

--- a/src/incatools/odk/templates/_dynamic_files.jinja2
+++ b/src/incatools/odk/templates/_dynamic_files.jinja2
@@ -32,6 +32,9 @@ import: {{ project.uribase }}/{% if project.uribase_suffix is not none %}{{ proj
 {%         endfor -%}
 {%       endif -%}
 {%     endif -%}
+{%     if project.orcidio_support -%}
+import: {{ project.uribase }}/{% if project.uribase_suffix is not none %}{{ project.uribase_suffix }}{% else %}{{ project.id }}{% endif %}/imports/orcidio_import.owl
+{%     endif -%}
 {%     if project.components is defined -%}
 {%       for component in project.components.products -%}
 import: {{ project.uribase }}/{% if project.uribase_suffix is not none %}{{ project.uribase_suffix }}{% else %}{{ project.id }}{% endif %}/components/{{ component.filename }}
@@ -89,7 +92,10 @@ Import(<{{ project.uribase }}/{% if project.uribase_suffix is not none %}{{ proj
 Import(<{{ project.uribase }}/{% if project.uribase_suffix is not none %}{{ project.uribase_suffix }}{% else %}{{ project.id }}{% endif %}/imports/{{ imp.id }}_import.owl>)
 {%         endfor -%}
 {%       endif -%}
-{%     endif %}
+{%     endif -%}
+{%     if project.orcidio_support -%}
+Import(<{{ project.uribase }}/{% if project.uribase_suffix is not none %}{{ project.uribase_suffix }}{% else %}{{ project.id }}{% endif %}/imports/orcidio_import.owl>)
+{%     endif -%}
 {%     if project.components is defined -%}
 {%       for component in project.components.products -%}
 Import(<{{ project.uribase }}/{% if project.uribase_suffix is not none %}{{ project.uribase_suffix }}{% else %}{{ project.id }}{% endif %}/components/{{ component.filename }}>)
@@ -256,6 +262,21 @@ Ontology(<{{ project.uribase }}/{% if project.uribase_suffix is not none %}{{ pr
 ^^^ src/ontology/imports/{{ imp.id }}_terms.txt
 {%   endfor -%}
 {% endif %}{# ! project.import_group is defined -#}
+{% if project.orcidio_support -%}
+^^^ src/ontology/imports/orcidio_import.owl
+Prefix(:=<{{ project.uribase }}/{% if project.uribase_suffix is not none %}{{ project.uribase_suffix }}{% else %}{{ project.id }}{% endif %}/imports/orcidio_import.owl>)
+Prefix(obo:=<http://purl.obolibrary.org/obo/>)
+Prefix(owl:=<http://www.w3.org/2002/07/owl#>)
+Prefix(rdf:=<http://www.w3.org/1999/02/22-rdf-syntax-ns#>)
+Prefix(xml:=<http://www.w3.org/XML/1998/namespace>)
+Prefix(xsd:=<http://www.w3.org/2001/XMLSchema#>)
+Prefix(rdfs:=<http://www.w3.org/2000/01/rdf-schema#>)
+Prefix(oboInOwl:=<http://www.geneontology.org/formats/oboInOwl#>)
+
+Ontology(<{{ project.uribase }}/{% if project.uribase_suffix is not none %}{{ project.uribase_suffix }}{% else %}{{ project.id }}{% endif %}/imports/orcidio_import.owl>
+# This is a placeholder, it will be regenerated when makefile is first executed.
+)
+{% endif -%}
 {#
 
   Metadata files.

--- a/src/incatools/odk/templates/src/ontology/Makefile.jinja2
+++ b/src/incatools/odk/templates/src/ontology/Makefile.jinja2
@@ -791,10 +791,17 @@ no-mirror-refresh-%:
 # ORCIDIO module
 # ----------------------------------------
 
+# By default, the ORCIDIO module is seeded from ORCID references in ALL
+# IRI-valued annotations in the ontology, regardless of the annotation
+# property. To seed only from annotations using specific properties,
+# override the following variable with the desired list of properties.
+ORCIDIO_PROPERTIES =
+
 ifeq ($(IMP),true)
 $(IMPORTDIR)/orcidio_import.owl: $(SRCMERGED) $(MIRRORDIR)/orcidio.owl | all_robot_plugins
 	$(ROBOT) odk:extract-orcids --input $(SRCMERGED) \
 	                            --orcid-file $(MIRRORDIR)/orcidio.owl \
+	                            $(foreach p, $(ORCIDIO_PROPERTIES),--property $(p)) \
 		 $(ANNOTATE_CONVERT_FILE)
 
 endif

--- a/src/incatools/odk/templates/src/ontology/Makefile.jinja2
+++ b/src/incatools/odk/templates/src/ontology/Makefile.jinja2
@@ -249,7 +249,7 @@ IMPORTS = {% for imp in project.import_group.products %} {{ imp.id }}{% endfor %
 {% else %}
 IMPORTS =
 {% endif %}
-IMPORT_ROOTS = {% if project.import_group.use_base_merging %} $(IMPORTDIR)/merged_import{% else %}$(patsubst %, $(IMPORTDIR)/%_import, $(IMPORTS)){% endif %}
+IMPORT_ROOTS = {% if project.import_group.use_base_merging %} $(IMPORTDIR)/merged_import{% else %}$(patsubst %, $(IMPORTDIR)/%_import, $(IMPORTS)){% endif %}{% if project.orcidio_support %} $(IMPORTDIR)//orcidio_import{% endif %}
 IMPORT_OWL_FILES = $(foreach n,$(IMPORT_ROOTS), $(n).owl)
 {%- if project.import_group.export_obo %}
 IMPORT_OBO_FILES = $(foreach n,$(IMPORT_ROOTS), $(n).obo)
@@ -785,6 +785,20 @@ no-mirror-refresh-%:
 		IMP=true IMP_LARGE=true MIR=false PAT=false $(IMPORTDIR)/$*_import.owl
 
 {% endif %}{# !project.import_group is defined -#}
+
+{% if project.orcidio_support -%}
+# ----------------------------------------
+# ORCIDIO module
+# ----------------------------------------
+
+ifeq ($(IMP),true)
+$(IMPORTDIR)/orcidio_import.owl: $(SRCMERGED) | all_robot_plugins
+	$(ROBOT) odk:extract-orcids -i $(SRCMERGED) \
+		 $(ANNOTATE_CONVERT_FILE)
+
+endif
+
+{% endif -%}
 
 {% if project.components is not none -%}
 # ----------------------------------------

--- a/src/incatools/odk/templates/src/ontology/Makefile.jinja2
+++ b/src/incatools/odk/templates/src/ontology/Makefile.jinja2
@@ -249,7 +249,7 @@ IMPORTS = {% for imp in project.import_group.products %} {{ imp.id }}{% endfor %
 {% else %}
 IMPORTS =
 {% endif %}
-IMPORT_ROOTS = {% if project.import_group.use_base_merging %} $(IMPORTDIR)/merged_import{% else %}$(patsubst %, $(IMPORTDIR)/%_import, $(IMPORTS)){% endif %}{% if project.orcidio_support %} $(IMPORTDIR)//orcidio_import{% endif %}
+IMPORT_ROOTS = {% if project.import_group.use_base_merging %} $(IMPORTDIR)/merged_import{% else %}$(patsubst %, $(IMPORTDIR)/%_import, $(IMPORTS)){% endif %}{% if project.orcidio_support %} $(IMPORTDIR)/orcidio_import{% endif %}
 IMPORT_OWL_FILES = $(foreach n,$(IMPORT_ROOTS), $(n).owl)
 {%- if project.import_group.export_obo %}
 IMPORT_OBO_FILES = $(foreach n,$(IMPORT_ROOTS), $(n).obo)
@@ -792,9 +792,25 @@ no-mirror-refresh-%:
 # ----------------------------------------
 
 ifeq ($(IMP),true)
-$(IMPORTDIR)/orcidio_import.owl: $(SRCMERGED) | all_robot_plugins
-	$(ROBOT) odk:extract-orcids -i $(SRCMERGED) \
+$(IMPORTDIR)/orcidio_import.owl: $(SRCMERGED) $(MIRRORDIR)/orcidio.owl | all_robot_plugins
+	$(ROBOT) odk:extract-orcids --input $(SRCMERGED) \
+	                            --orcid-file $(MIRRORDIR)/orcidio.owl \
 		 $(ANNOTATE_CONVERT_FILE)
+
+endif
+
+ifeq ($(MIR),true)
+.PHONY: download-mirror-orcidio
+download-mirror-orcidio: | $(TMPDIR) $(MIRRORDIR)
+	@odk-helper download --output $(TMPDIR)/$@.owl \
+	                    --reference $(MIRRORDIR)/orcidio.owl{% if project.import_group is defined %} \
+	                    --max-retry {{ project.import_group.mirror_retry_download }}{% endif %} \
+	                    https://w3id.org/orcidio/orcidio.owl
+
+$(MIRRORDIR)/orcidio.owl: download-mirror-orcidio
+	@if [ -f $(TMPDIR)/download-mirror-orcidio.owl ]; then \
+		cp $(TMPDIR)/download-mirror-orcidio.owl $@ ; \
+	fi
 
 endif
 

--- a/src/incatools/odk/templates/src/ontology/catalog-v001.xml.jinja2
+++ b/src/incatools/odk/templates/src/ontology/catalog-v001.xml.jinja2
@@ -11,6 +11,9 @@
 {%-       endfor %}
 {%-     endif %}
 {%-   endif %}
+{%-   if project.orcidio_support %}
+    <uri name="{{project.uribase}}/{% if project.uribase_suffix is not none %}{{ project.uribase_suffix }}{% else %}{{ project.id }}{% endif %}/imports/orcidio_import.owl" uri="imports/orcidio_import.owl"/>
+{%-   endif %}
 {%-   if project.components is defined %}
 {%-     for component in project.components.products %}
     <uri name="{{project.uribase}}/{% if project.uribase_suffix is not none %}{{ project.uribase_suffix }}{% else %}{{ project.id }}{% endif %}/components/{{component.filename}}" uri="components/{{component.filename}}"/>


### PR DESCRIPTION
This PR adds automatic support for importing the [ORCIDIO](https://github.com/cthoyt/orcidio) “ontology” (https://github.com/INCATools/ontology-development-kit/issues/1312).

It adds a new project-level configuration option: `orcidio_support`. When enabled, it creates a custom import module for ORCIDIO (`$(IMPORTDIR)/orcidio_import.owl`), which is generated by (1) extracting all ORCID references in IRI-valued annotations within the source ontology and (2) extracting all individuals corresponding to the referenced ORCIDs from the ORCIDIO ontology.